### PR TITLE
ci: fix ramsey/composer-install version comment for renovate

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -24,7 +24,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
         with:
           working-directory: backend
           composer-options: "--ignore-platform-req=ext-opentelemetry --no-scripts"


### PR DESCRIPTION
Tag is `4.0.0`, not `v4.0.0` — renovate looked up `v4.0.0` and failed with "Could not determine new digest for update".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration comments for internal CI/CD processes. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->